### PR TITLE
fix: exec command

### DIFF
--- a/launcher-native/exec.go
+++ b/launcher-native/exec.go
@@ -47,6 +47,9 @@ func (s *Server) ExecCommand(w http.ResponseWriter, r *http.Request) {
 	if req.Terminal {
 		args = append([]string{"-e", command}, req.Args...)
 		command = terminal
+	} else {
+		args = append([]string{"-c", command}, req.Args...)
+		command = "sh"
 	}
 
 	var stdout strings.Builder


### PR DESCRIPTION
error case

```
[Desktop Entry]
Name=IntelliJ IDEA Ultimate 2023.3.2
Exec="/home/eric/.local/share/JetBrains/Toolbox/apps/intellij-idea-ultimate/bin/idea.sh" %u
Version=1.0
Type=Application
Categories=Development;IDE;
Terminal=false
Icon=/home/eric/.local/share/JetBrains/Toolbox/apps/intellij-idea-ultimate/bin/idea.svg
Comment=The Leading Java and Kotlin IDE
StartupWMClass=jetbrains-idea
StartupNotify=true
```
