### PR TITLE
refactor: simplily and correct launch application

### DIFF
--- a/electron/api.ts
+++ b/electron/api.ts
@@ -63,7 +63,7 @@ class LauncherApi {
         this.getMain().webContents.focus()
     }
 
-    public toggle = ()=>{
+    public toggle = () => {
         if (this.getMain().isVisible()) {
             this.hide()
         } else {
@@ -83,7 +83,7 @@ class LauncherApi {
 
     public async execCommand({data}: { data: any }) {
         const {command, args, terminal, stdin} = data
-        return await execCommand(command, terminal, stdin)
+        return await execCommand(command, args, terminal, stdin)
     }
 
     public async spawn({data}: { data: any }) {

--- a/electron/api.ts
+++ b/electron/api.ts
@@ -83,7 +83,7 @@ class LauncherApi {
 
     public async execCommand({data}: { data: any }) {
         const {command, args, terminal, stdin} = data
-        return await execCommand(command, args ? args : [], terminal, stdin)
+        return await execCommand(command, terminal, stdin)
     }
 
     public async spawn({data}: { data: any }) {

--- a/launcher-native/exec.go
+++ b/launcher-native/exec.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"encoding/json"
+	"github.com/fzdwx/launcher/launcher-native/pkg/json"
 	"net/http"
 	"os/exec"
 	"strings"
@@ -39,28 +39,35 @@ func has(name string) bool {
 }
 
 func (s *Server) ExecCommand(w http.ResponseWriter, r *http.Request) {
-	var req = ExecCommandReq{}
-	_ = json.NewDecoder(r.Body).Decode(&req)
+	var (
+		req, err   = json.DecodeFrom2[ExecCommandReq](r.Body)
+		cmdPreArgs []string
+		stdout     strings.Builder
+		command    = ""
+	)
+	if err != nil {
+		_, _ = w.Write([]byte(err.Error()))
+		return
+	}
 
-	command := strings.TrimSpace(req.Command)
-  var args []string
+	command = strings.TrimSpace(req.Command)
+
 	if req.Terminal {
-		args = append([]string{"-e"}, command)
+		cmdPreArgs = append([]string{"-e"}, command)
 		command = terminal
 	} else {
-		args = append([]string{"-c"}, command)
+		cmdPreArgs = append([]string{"-c"}, command)
 		command = "sh"
 	}
 
-	var stdout strings.Builder
-  
+	args := append(cmdPreArgs, req.Args...)
 	cmd := exec.Command(command, args...)
 	if req.Stdin != "" {
 		cmd.Stdin = strings.NewReader(req.Stdin)
 	}
 	cmd.Stdout = &stdout
 
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
 		_, _ = w.Write([]byte(err.Error()))
 		return

--- a/launcher-native/exec.go
+++ b/launcher-native/exec.go
@@ -43,16 +43,17 @@ func (s *Server) ExecCommand(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewDecoder(r.Body).Decode(&req)
 
 	command := strings.TrimSpace(req.Command)
-	args := req.Args
+  var args []string
 	if req.Terminal {
-		args = append([]string{"-e", command}, req.Args...)
+		args = append([]string{"-e"}, command)
 		command = terminal
 	} else {
-		args = append([]string{"-c", command}, req.Args...)
+		args = append([]string{"-c"}, command)
 		command = "sh"
 	}
 
 	var stdout strings.Builder
+  
 	cmd := exec.Command(command, args...)
 	if req.Stdin != "" {
 		cmd.Stdin = strings.NewReader(req.Stdin)

--- a/launcher-native/exec.go
+++ b/launcher-native/exec.go
@@ -40,10 +40,10 @@ func has(name string) bool {
 
 func (s *Server) ExecCommand(w http.ResponseWriter, r *http.Request) {
 	var (
-		req, err   = json.DecodeFrom2[ExecCommandReq](r.Body)
-		cmdPreArgs []string
-		stdout     strings.Builder
-		command    = ""
+		req, err = json.DecodeFrom2[ExecCommandReq](r.Body)
+		args     []string
+		stdout   strings.Builder
+		command  = ""
 	)
 	if err != nil {
 		_, _ = w.Write([]byte(err.Error()))
@@ -53,14 +53,14 @@ func (s *Server) ExecCommand(w http.ResponseWriter, r *http.Request) {
 	command = strings.TrimSpace(req.Command)
 
 	if req.Terminal {
-		cmdPreArgs = append([]string{"-e"}, command)
+		args = append([]string{"-e"}, command)
 		command = terminal
 	} else {
-		cmdPreArgs = append([]string{"-c"}, command)
+		args = append([]string{"-c"}, command)
 		command = "sh"
 	}
 
-	args := append(cmdPreArgs, req.Args...)
+	args = append(args, req.Args...)
 	cmd := exec.Command(command, args...)
 	if req.Stdin != "" {
 		cmd.Stdin = strings.NewReader(req.Stdin)

--- a/launcher-native/pkg/json/json.go
+++ b/launcher-native/pkg/json/json.go
@@ -20,3 +20,15 @@ func EncodeTo[T any](write io.Writer, v T) error {
 func DecodeFrom[T any](read io.Reader, v T) error {
 	return json.NewDecoder(read).Decode(v)
 }
+
+func DecodeFrom2[T any](read io.Reader) (*T, error) {
+	var (
+		v   T
+		err = DecodeFrom(read, &v)
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}

--- a/src/components/self/application.tsx
+++ b/src/components/self/application.tsx
@@ -50,9 +50,8 @@ const runApplication = (app: Application) => {
         .replace("%u", "").replace("%U", "")
         .replace("%f", "").replace("%F", "")
         .trim()
-        .split(" ")
 
-    execCommand(commands[0], commands.slice(1), app.terminal)
+    execCommand(commands, app.terminal)
     window.launcher.hide()
     addAppRunCount(app)
 }

--- a/src/components/self/application.tsx
+++ b/src/components/self/application.tsx
@@ -3,7 +3,7 @@ import {Action, UseRegisterActions} from "@/lib/command";
 import fs from "node:fs";
 import {Application, execCommand} from "@/native";
 
-export const ApplicationKind  ="Application"
+export const ApplicationKind = "Application"
 
 export const useRegisterApps = (useRegisterActions: UseRegisterActions) => {
     const [apps, setApps] = useState<Application[]>([])
@@ -51,7 +51,7 @@ const runApplication = (app: Application) => {
         .replace("%f", "").replace("%F", "")
         .trim()
 
-    execCommand("code",["~/.zshrc"], false)
+    execCommand(commands, [], app.terminal)
     window.launcher.hide()
     addAppRunCount(app)
 }

--- a/src/components/self/application.tsx
+++ b/src/components/self/application.tsx
@@ -51,7 +51,7 @@ const runApplication = (app: Application) => {
         .replace("%f", "").replace("%F", "")
         .trim()
 
-    execCommand(commands, app.terminal)
+    execCommand("code",["~/.zshrc"], false)
     window.launcher.hide()
     addAppRunCount(app)
 }

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -1,9 +1,9 @@
 import {Shortcut} from "@/native/types";
 
-const execCommand = async (command: string, terminal?: boolean, stdin?: string) => {
+const execCommand = async (command: string, args?: string[], terminal?: boolean, stdin?: string) => {
     return (await fetch("http://localhost:35677/api/exec/command", {
         method: "POST",
-        body: JSON.stringify({command, terminal, stdin})
+        body: JSON.stringify({command, args: args ? args : [], terminal, stdin})
     })).text()
 }
 

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -1,9 +1,9 @@
 import {Shortcut} from "@/native/types";
 
-const execCommand = async (command: string, args: string[], terminal?: boolean, stdin?: string) => {
+const execCommand = async (command: string, terminal?: boolean, stdin?: string) => {
     return (await fetch("http://localhost:35677/api/exec/command", {
         method: "POST",
-        body: JSON.stringify({command, args, terminal, stdin})
+        body: JSON.stringify({command, terminal, stdin})
     })).text()
 }
 


### PR DESCRIPTION
Application with `exec = abc def ghi` should be run with:

`exec.Command("sh", ["-c", "abc def ghi"])`

instead of:

`exec.Command("sh", ["-c", "abc", "def", "ghi"])`